### PR TITLE
Very small changes made from testing with Zabbix 2.0, 2.2, and 2.4.  …

### DIFF
--- a/ZabbixDockerTemplate.xml
+++ b/ZabbixDockerTemplate.xml
@@ -1202,7 +1202,7 @@
                     <multiplier>0</multiplier>
                     <snmp_oid/>
                     <key>docker.version</key>
-                    <delay>60</delay>
+                    <delay>3600</delay>
                     <history>90</history>
                     <trends>365</trends>
                     <status>0</status>
@@ -1338,7 +1338,7 @@ last(&quot;docker.containers.running&quot;)</params>
                     <privatekey/>
                     <port/>
                     <filter>:</filter>
-                    <lifetime>7</lifetime>
+                    <lifetime>2</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>

--- a/testtools/testrun.sh
+++ b/testtools/testrun.sh
@@ -4,12 +4,12 @@
 docker build --tag="rpsedlak/memkiller" .
 
 # next, start some standard stuff
-docker run --name="httpd-1" httpd
-docker run --name="httpd-2-pause" httpd
-docker run --name="httpd-3-kill" httpd
-docker run --name="redis-1" redis:2.8
-docker run --name="redis-2-pause" redis:2.8
-docker run --name="redis-3-kill" redis:2.8
+docker run -d --name="httpd-1" httpd
+docker run -d --name="httpd-2-pause" httpd
+docker run -d --name="httpd-3-kill" httpd
+docker run -d --name="redis-1" redis:2.8
+docker run -d --name="redis-2-pause" redis:2.8
+docker run -d --name="redis-3-kill" redis:2.8
 
 # next, pause a container
 docker pause httpd-2-pause
@@ -20,6 +20,6 @@ docker kill httpd-3-kill
 docker kill redis-3-kill
 
 # last, run the memkiller image
-docker run --memory=4M --name="oom-test" rpsedlak/memkiller
+docker run -d --memory=4M --name="oom-test" rpsedlak/memkiller
 
 


### PR DESCRIPTION
…Changed the lifetime value for discovered containers from 7 days to 2 days in the cases where the containers are destroyed they will be removed after 2 days.
