### PR TITLE
Update userparameter_zabbixdocker.conf

### DIFF
--- a/userparameter_zabbixdocker.conf
+++ b/userparameter_zabbixdocker.conf
@@ -10,7 +10,7 @@
 UserParameter=docker.version, docker -v
 
 UserParameter=docker.running.centos, ps -ef | grep 'docker -d' | grep -v grep | wc -l
-UserParameter=docker.running.ubuntu, ps -ef | grep 'docker daemon' | grep -v grep | wc -l
+UserParameter=docker.running.ubuntu, ps -ef | grep 'dockerd' | grep -v grep | wc -l
 
 UserParameter=docker.containers.running, docker ps -q | wc -l
 


### PR DESCRIPTION
Minor change required to make this test work on recent Ubuntu server variants (16.04 LTS) with current docker builds.