### PR TITLE
Update zabbix-docker-stats.py

### DIFF
--- a/zabbix-docker-stats.py
+++ b/zabbix-docker-stats.py
@@ -70,13 +70,13 @@ def lmem(data):
      return recalc(data[3])
 
 def pmem(data):
-     return recalc(data[4])
-
-def inet(data):
      return recalc(data[5])
 
-def onet(data):
+def inet(data):
      return recalc(data[6])
+
+def onet(data):
+     return recalc(data[8])
 
 options = {
     'pcpu':pcpu,

--- a/zabbix-docker-stats.py
+++ b/zabbix-docker-stats.py
@@ -10,7 +10,7 @@
 # Version: 1.0
 #
 # Author: Richard Sedlak
-#
+# For docker version 18
 #################################################################
 
 import sys

--- a/zabbix-docker-stats.py
+++ b/zabbix-docker-stats.py
@@ -67,7 +67,7 @@ def umem(data):
      return recalc(data[2])
 
 def lmem(data):
-     return recalc(data[3])
+     return recalc(data[4])
 
 def pmem(data):
      return recalc(data[5])

--- a/zabbix-docker-stats.py
+++ b/zabbix-docker-stats.py
@@ -61,22 +61,22 @@ def recalc(data):
      return value
 
 def pcpu(data):
-     return recalc(data[2])
+     return recalc(data[1])
 
 def umem(data):
-     return recalc(data[3])
+     return recalc(data[2])
 
 def lmem(data):
-     return recalc(data[5])
+     return recalc(data[3])
 
 def pmem(data):
-     return recalc(data[6])
+     return recalc(data[4])
 
 def inet(data):
-     return recalc(data[7])
+     return recalc(data[5])
 
 def onet(data):
-     return recalc(data[9])
+     return recalc(data[6])
 
 options = {
     'pcpu':pcpu,


### PR DESCRIPTION
changed the list index by -1 for the functions calling recalc(). It should now reflect the output of "docker stats"